### PR TITLE
com.vba_m.visualboyadvance-m.yaml: Adjust filesystem access to rw

### DIFF
--- a/com.vba_m.visualboyadvance-m.yaml
+++ b/com.vba_m.visualboyadvance-m.yaml
@@ -13,7 +13,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
-  - --filesystem=host:ro
+  - --filesystem=host:rw
 
 cleanup:
   - /lib/cmake


### PR DESCRIPTION
This is needed or vba-m won't be able to save progress in games as it writes battery files in the directory of the loaded game, or in the filesystem you tell the app to save it too.